### PR TITLE
Updated normalized frequency formula

### DIFF
--- a/lab0-intro/GBM8378_Lab0_Intro.ipynb
+++ b/lab0-intro/GBM8378_Lab0_Intro.ipynb
@@ -506,7 +506,7 @@
     "# Exercice 3: Filtrage\n",
     "\n",
     "**Question 3.1.** Filtrer le signal bruité (2.5.) à l’aide d’un filtre de Butterworth du deuxième ordre passe bas\n",
-    "à 90 Hz (Fc). Note: La “Normalized cutoff frequency” de Butterworth est ici égale à Fc/Fs/2.\n",
+    "à 90 Hz (Fc). Note: La “Normalized cutoff frequency” de Butterworth est ici égale à Fc/(Fs/2).\n",
     "\n",
     "Astuce: Utilisez les fonctions <a href=\"https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.butter.html\"> scipy.signal.butter()</a> et <a href=\"https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.filtfilt.html\"> scipy.signal.filtfilt()</a>"
    ]
@@ -714,7 +714,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.6.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Parentheses were missing in the normalized frequency formula used for the Butterworth filtering.