### PR TITLE
Fix binder badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started with Python, we recommend [this excellent tutorial](https://www.y
 ## Getting started (with Binder)
 
 Click on the Binder badge:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jcohenadad/GBM8378/r20220114)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jcohenadad/GBM8378/HEAD?urlpath=%2Ftree%2F)
 
 Wait for Binder to finish building the environment (can take 5-10 minutes), then click on the Jupyter notebook. E.g.: under `lab3-irm/gbm8378-lab3-irm.ipynb`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started with Python, we recommend [this excellent tutorial](https://www.y
 ## Getting started (with Binder)
 
 Click on the Binder badge:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jcohenadad/GBM8378/r20220114?urlpath=/tree/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jcohenadad/GBM8378/r20220114)
 
 Wait for Binder to finish building the environment (can take 5-10 minutes), then click on the Jupyter notebook. E.g.: under `lab3-irm/gbm8378-lab3-irm.ipynb`.
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Polytechnique Montreal course "Principes d'imagerie biomédicale".
 
-This repository includes the lab material for the course 
+This repository includes the lab material for the course
 
 ## Documentation and Ressource
 
-To get started with Python, we recommend [this excellent tutorial](https://www.youtube.com/playlist?list=PLnzBBbvhjz4X3htDbNF0aJEDVtny48GI0) (in French) made by Guillaume Sheehy. 
+To get started with Python, we recommend [this excellent tutorial](https://www.youtube.com/playlist?list=PLnzBBbvhjz4X3htDbNF0aJEDVtny48GI0) (in French) made by Guillaume Sheehy.
 
 ## Getting started (with Binder)
 
 Click on the Binder badge:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jcohenadad/GBM8378/r20220114)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jcohenadad/GBM8378/r20220114?urlpath=/tree/)
 
 Wait for Binder to finish building the environment (can take 5-10 minutes), then click on the Jupyter notebook. E.g.: under `lab3-irm/gbm8378-lab3-irm.ipynb`.
 
@@ -45,7 +45,7 @@ jupyter notebook
 - Make sure that your prompt is currently on the `GBM8378` folder when you call the `environment.yml` file.
 - For Windows user, you might need to type these commands in `Anaconda Prompt` if `cmd` does not recognize `conda`.
 
-**Make sure that you have the last version of the files by pulling the repo before every new lab** (`git pull`). Move your Notebooks elsewhere if you don't want them to be overwritten by the new clone. 
+**Make sure that you have the last version of the files by pulling the repo before every new lab** (`git pull`). Move your Notebooks elsewhere if you don't want them to be overwritten by the new clone.
 
 ## Create PDF
 While on the jupyter notebook, print the page and export/save as PDF.

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6
   - pip:
     - numpy==1.18.2
-    - jupyter
+    - jupyterlab
     - pydicom==1.4.1
     - nibabel==2.5.1
     - niwidgets==0.2.2


### PR DESCRIPTION
The binder badge has been broken. Binder seems to have switched some default behaviour at the beginning of 2022 which coincides with then we observed the problem. This thread discusses it in more detail. The fix specifies in the path to use the old behaviour.